### PR TITLE
Pinning rltest to the last release prior to redis-py 4 as a requirement

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/RedisLabsModules/RLTest.git@master#egg=rltest
+rltest==0.4.2
 sqlalchemy~=1.3.0
 pymysql>=1.0.2
 cryptography>=36.0.1


### PR DESCRIPTION
This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.
