### PR TITLE
fix #88 avoid loading null fields to Redis Hash

### DIFF
--- a/src/main/java/com/redislabs/ReadSource.java
+++ b/src/main/java/com/redislabs/ReadSource.java
@@ -82,9 +82,11 @@ public class ReadSource extends Source implements ForeachOperation<KeysReaderRec
           GearsBuilder.overrideReply(error);
           throw new Exception(error);
         }
-        command.add(propKey);
-        Object value = e.getValue();
-        command.add(pd.convertToStr(value));
+        if (value != null) {
+          command.add(propKey);
+          Object value = e.getValue();
+          command.add(pd.convertToStr(value));
+        }
       }
       
       
@@ -131,16 +133,22 @@ public class ReadSource extends Source implements ForeachOperation<KeysReaderRec
             GearsBuilder.overrideReply(error);
             throw new Exception(error);
           }
-          response.add(propKey);
-          Object value = e.getValue();
-          response.add(pd.convertToStr(value));
+          if (value != null){
+            response.add(propKey);
+            Object value = e.getValue();
+            response.add(pd.convertToStr(value));
+          }
         }
       }else {
         for(String f : fields) {
           if(res.containsKey(f)) {
             PropertyData pd = getPropertyMapping(f);
             Object value = res.get(f);
-            response.add(pd != null ? pd.convertToStr(value) : value.toString());
+            if( value == null) {
+              response.add(null);
+            } else {
+              response.add(pd != null ? pd.convertToStr(value) : value.toString());
+            }
           }else {
             response.add(null);
           }

--- a/src/main/java/com/redislabs/ReadSource.java
+++ b/src/main/java/com/redislabs/ReadSource.java
@@ -82,9 +82,9 @@ public class ReadSource extends Source implements ForeachOperation<KeysReaderRec
           GearsBuilder.overrideReply(error);
           throw new Exception(error);
         }
+        Object value = e.getValue();
         if (value != null) {
           command.add(propKey);
-          Object value = e.getValue();
           command.add(pd.convertToStr(value));
         }
       }
@@ -133,9 +133,9 @@ public class ReadSource extends Source implements ForeachOperation<KeysReaderRec
             GearsBuilder.overrideReply(error);
             throw new Exception(error);
           }
+          Object value = e.getValue();
           if (value != null){
             response.add(propKey);
-            Object value = e.getValue();
             response.add(pd.convertToStr(value));
           }
         }


### PR DESCRIPTION
1. Avoid loading null fields to Redis
2. Reply should return `nil` if specific list of field was requested 