### PR TITLE
Extra inforamtion on info trigger, update postgresql dep to 42.5.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.4.2</version>
+			<version>42.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>

--- a/src/main/java/com/redislabs/Connector.java
+++ b/src/main/java/com/redislabs/Connector.java
@@ -473,7 +473,7 @@ MapOperation<HashMap<String, Object>, HashMap<String, Object>>{
         "userName", userName, "dialect", dialect, "uuid", uuid,
         "registrationId", registrationId, "batchSize", Integer.toString(batchSize),
         "duration", Integer.toString(duration), "retryInterval", Integer.toString(retryInterval),
-        "streamName", expectedStreamName, "pendingClients", Integer.toString(queue.size())));
+        "streamName", expectedStreamName, "pendingClients", Integer.toString(queue.size()), "errorsToDLQ", Boolean.toString(getErrorsToDLQ())));
     Long backlog = (Long)GearsBuilder.execute("xlen", expectedStreamName);
     s.add("backlog");
     s.add(Long.toString(backlog));

--- a/src/main/java/com/redislabs/WriteBehind.java
+++ b/src/main/java/com/redislabs/WriteBehind.java
@@ -265,7 +265,7 @@ public class WriteBehind{
         GearsBuilder.log(String.format("Register source %s to connector %s", temp.getName(), temp.getConnector()));
         if(temp instanceof WriteSource) {
           WriteSource s = (WriteSource)temp;
-          new WriteSource(s.getName(), s.getConnector(), s.getXmlDef(), s.isWriteThrough(), s.getTimeout(), s.writeOnChange);
+          new WriteSource(s.getName(), s.getConnector(), s.getXmlDef(), s.isWriteThrough(), s.getTimeout(), s.getWriteOnChange());
         } else if(temp instanceof ReadSource) {
           ReadSource s = (ReadSource)temp;
           new ReadSource(s.getName(), s.getConnector(), s.getXmlDef(), s.getExpire());

--- a/src/main/java/com/redislabs/WriteSource.java
+++ b/src/main/java/com/redislabs/WriteSource.java
@@ -198,6 +198,8 @@ public class WriteSource extends Source{
     s.add(String.format("%s-{%s}", streamName, GearsBuilder.hashtag()));
     s.add("policy");
     s.add(writeThrough ? "writeThrough" : "writeBehind");
+    s.add("writeOnChangeEvent");
+    s.add(Boolean.toString(writeOnChange));
     if(writeThrough) {
       s.add("timeout");
       s.add(Integer.toString(timeout));


### PR DESCRIPTION
The PR adds 2 fields to info connectors and info sources:
1. errorsToDLQ - whether or not errors are configured to be sent to errors queue.
2. writeOnChangeEvent - whether or not to register to change events.

In addition, the PR updates postgresql driver to 42.5.4