### PR TITLE
Get password using rgtrigger

### DIFF
--- a/src/main/java/com/redislabs/RGHibernate.java
+++ b/src/main/java/com/redislabs/RGHibernate.java
@@ -100,8 +100,7 @@ public class RGHibernate implements Closeable, Serializable {
     String generatedXmlConf = xmlConf;
     
     try {
-      Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword", name);
-      String dbpass = (String) res[0];
+      String dbpass = WriteBehind.getPassword(name);
       generatedXmlConf = generatedXmlConf.replaceAll("(connection\\.password\">)[^<]*", "$1" + dbpass);
     } catch (Exception e) {
       GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);

--- a/src/main/java/com/redislabs/RGHibernate.java
+++ b/src/main/java/com/redislabs/RGHibernate.java
@@ -99,15 +99,6 @@ public class RGHibernate implements Closeable, Serializable {
   private void generateSession() {
     String generatedXmlConf = WriteBehind.setPasswordIfNeeded(xmlConf, name);
     
-    try {
-      String dbpass = WriteBehind.getPassword(name);
-      generatedXmlConf = WriteBehind.setPasswordOnXmlDel(dbpass, generatedXmlConf);
-    } catch (Exception e) {
-      GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);
-    } finally {
-      Thread.currentThread().setContextClassLoader(RGHibernate.class.getClassLoader());
-    }
-    
     registry = new StandardServiceRegistryBuilder()
         .configure(InMemoryURLFactory.getInstance().build("configuration", generatedXmlConf)).build();
     MetadataSources sources = new MetadataSources(registry);

--- a/src/main/java/com/redislabs/RGHibernate.java
+++ b/src/main/java/com/redislabs/RGHibernate.java
@@ -98,8 +98,9 @@ public class RGHibernate implements Closeable, Serializable {
 
   private void generateSession() {
     String generatedXmlConf = xmlConf;
+    
     try {
-      Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword");
+      Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword", name);
       String dbpass = (String) res[0];
       generatedXmlConf = generatedXmlConf.replaceAll("(connection\\.password\">)[^<]*", "$1" + dbpass);
     } catch (Exception e) {
@@ -107,6 +108,7 @@ public class RGHibernate implements Closeable, Serializable {
     } finally {
       Thread.currentThread().setContextClassLoader(RGHibernate.class.getClassLoader());
     }
+    
     registry = new StandardServiceRegistryBuilder()
         .configure(InMemoryURLFactory.getInstance().build("configuration", generatedXmlConf)).build();
     MetadataSources sources = new MetadataSources(registry);

--- a/src/main/java/com/redislabs/RGHibernate.java
+++ b/src/main/java/com/redislabs/RGHibernate.java
@@ -97,11 +97,11 @@ public class RGHibernate implements Closeable, Serializable {
   }
 
   private void generateSession() {
-    String generatedXmlConf = xmlConf;
+    String generatedXmlConf = WriteBehind.setPasswordIfNeeded(xmlConf, name);
     
     try {
       String dbpass = WriteBehind.getPassword(name);
-      generatedXmlConf = generatedXmlConf.replaceAll("(connection\\.password\">)[^<]*", "$1" + dbpass);
+      generatedXmlConf = WriteBehind.setPasswordOnXmlDel(dbpass, generatedXmlConf);
     } catch (Exception e) {
       GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);
     } finally {

--- a/src/main/java/com/redislabs/Source.java
+++ b/src/main/java/com/redislabs/Source.java
@@ -66,8 +66,7 @@ public abstract class Source implements OnRegisteredOperation, OnUnregisteredOpe
     String generatedXmlConf = RGHibernate.get(connector).getXmlConf();
     
     try {
-      Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword", connector);
-      String dbpass = (String) res[0];
+      String dbpass = WriteBehind.getPassword(name);
       generatedXmlConf = generatedXmlConf.replaceAll("(connection\\.password\">)[^<]*", "$1" + dbpass);
     } catch (Exception e) {
       GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);

--- a/src/main/java/com/redislabs/Source.java
+++ b/src/main/java/com/redislabs/Source.java
@@ -66,7 +66,7 @@ public abstract class Source implements OnRegisteredOperation, OnUnregisteredOpe
     String generatedXmlConf = RGHibernate.get(connector).getXmlConf();
     
     try {
-      Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword");
+      Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword", connector);
       String dbpass = (String) res[0];
       generatedXmlConf = generatedXmlConf.replaceAll("(connection\\.password\">)[^<]*", "$1" + dbpass);
     } catch (Exception e) {

--- a/src/main/java/com/redislabs/Source.java
+++ b/src/main/java/com/redislabs/Source.java
@@ -63,16 +63,7 @@ public abstract class Source implements OnRegisteredOperation, OnUnregisteredOpe
     this.xmlDef = xmlDef;
     this.propertyMappings = new HashMap<>();
     
-    String generatedXmlConf = RGHibernate.get(connector).getXmlConf();
-    
-    try {
-      String dbpass = WriteBehind.getPassword(name);
-      generatedXmlConf = generatedXmlConf.replaceAll("(connection\\.password\">)[^<]*", "$1" + dbpass);
-    } catch (Exception e) {
-      GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);
-    } finally {
-      Thread.currentThread().setContextClassLoader(Source.class.getClassLoader());
-    }
+    String generatedXmlConf = WriteBehind.setPasswordIfNeeded(RGHibernate.get(connector).getXmlConf(), connector);
 
     StandardServiceRegistry tempRegistry = new StandardServiceRegistryBuilder()
          .configure( InMemoryURLFactory.getInstance().build("configuration", generatedXmlConf))

--- a/src/main/java/com/redislabs/WriteBehind.java
+++ b/src/main/java/com/redislabs/WriteBehind.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import gears.ExecutionMode;
 import gears.GearsBuilder;
+import gears.LogLevel;
 import gears.operations.FlatMapOperation;
 import gears.readers.CommandReader;
 
@@ -79,9 +80,26 @@ public class WriteBehind{
     return String.format("%d.%d.%d", major, minor, patch);
   }
 
-  public static String getPassword(String connectorName) {
+  static String getPassword(String connectorName) {
     Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword", connectorName);
     return (String) res[0];
+  }
+  
+  static String setPasswordOnXmlDel(String password, String xmlDef) {
+    return xmlDef.replaceAll("(connection\\.password\">)[^<]*", "$1" + password);
+  }
+
+  public static String setPasswordIfNeeded(String xmlDef, String connectorName) {
+    String generatedXmlConf = xmlDef;
+    try {
+      String dbpass = WriteBehind.getPassword(connectorName);
+      generatedXmlConf = WriteBehind.setPasswordOnXmlDel(dbpass, generatedXmlConf);
+    } catch (Exception e) {
+      GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);
+    } finally {
+      Thread.currentThread().setContextClassLoader(RGHibernate.class.getClassLoader());
+    }
+    return generatedXmlConf;
   }
   
   public static void main(String[] args) throws Exception {

--- a/src/main/java/com/redislabs/WriteBehind.java
+++ b/src/main/java/com/redislabs/WriteBehind.java
@@ -79,6 +79,11 @@ public class WriteBehind{
     return String.format("%d.%d.%d", major, minor, patch);
   }
 
+  public static String getPassword(String connectorName) {
+    Object[] res = (Object[])  GearsBuilder.execute("RG.TRIGGER", "rghibernateGetPassword", connectorName);
+    return (String) res[0];
+  }
+  
   public static void main(String[] args) throws Exception {
     String verStr = getStringVersion(VERSION);
     if(args.length == 1 && args[0].equals("version")) {

--- a/src/main/java/com/redislabs/WriteBehind.java
+++ b/src/main/java/com/redislabs/WriteBehind.java
@@ -92,8 +92,8 @@ public class WriteBehind{
   public static String setPasswordIfNeeded(String xmlDef, String connectorName) {
     String generatedXmlConf = xmlDef;
     try {
-      String dbpass = WriteBehind.getPassword(connectorName);
-      generatedXmlConf = WriteBehind.setPasswordOnXmlDel(dbpass, generatedXmlConf);
+      String dbpass = getPassword(connectorName);
+      generatedXmlConf = setPasswordOnXmlDel(dbpass, generatedXmlConf);
     } catch (Exception e) {
       GearsBuilder.log(String.format("Failing generating password using 'RG.TRIGGER rghibernateGetPassword' using regular xml configuration, %s.", e), LogLevel.VERBOSE);
     } finally {


### PR DESCRIPTION
The PR allows to get the connector password using another RG.TRIGGER registration that was register separately. This allows the user to add a costume code for password retrieval. RGHIBERNATE pass the connector name to the trigger so the password retrieval could get different passwords to different connectors.
In case of failure, the default password that was set on the xml configuration is kept.